### PR TITLE
Implement scoreboard and planet monsters

### DIFF
--- a/src/app/galaxy/page.tsx
+++ b/src/app/galaxy/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { Progress, Planet } from '@/types/curriculum';
 import { planetsInfo, getPlanetLevels } from '@/lib/curriculum-data';
+import { planetMonsters } from '@/lib/monsters';
 import { useUser } from '@/contexts/UserContext';
 import UserLogin from '@/components/UserLogin';
 import ClientOnly from '@/components/ClientOnly';
@@ -119,6 +120,7 @@ export default function GalaxyNavigation() {
             const isUnlocked = progress.unlockedPlanets.includes(planet.id);
             const planetProgress = progress.planetProgress[planet.id];
             const completionPercentage = calculatePlanetCompletion(planet.id);
+            const monster = planetMonsters[planet.id][0];
             const highestLevel = getHighestUnlockedLevel(planet.id);
             const currentLevelProgress = planetProgress?.levelProgress[highestLevel];
 
@@ -138,6 +140,11 @@ export default function GalaxyNavigation() {
                     <div className="text-6xl mb-4">{planet.icon}</div>
                     <h3 className="text-2xl font-bold mb-2">{planet.name}</h3>
                     <p className="text-white/90 mb-4">{planet.description}</p>
+                    {monster && (
+                      <div className="mb-2 text-lg">
+                        {monster.emoji} <span className="text-sm">{monster.name}</span>
+                      </div>
+                    )}
                     
                     {/* Level Progress */}
                     {isUnlocked && (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,11 +39,14 @@ export default function Home() {
       </div>
 
       {/* Main Action */}
-      <div className="mb-12">
+      <div className="mb-12 flex flex-col items-center gap-4">
         <Link href="/galaxy">
           <button className="bg-gradient-to-r from-purple-600 to-pink-600 text-white text-2xl font-bold px-12 py-6 rounded-full shadow-2xl hover:shadow-3xl transform hover:scale-105 transition-all duration-300">
             🚀 Explore the Galaxy
           </button>
+        </Link>
+        <Link href="/scoreboard" className="text-purple-600 underline font-semibold">
+          View Scoreboard
         </Link>
       </div>
 

--- a/src/app/scoreboard/page.tsx
+++ b/src/app/scoreboard/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface ScoreEntry {
+  id: string;
+  name: string;
+  points: number;
+}
+
+export default function ScoreboardPage() {
+  const [scores, setScores] = useState<ScoreEntry[]>([]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const users = JSON.parse(localStorage.getItem('english-warrior-users') || '[]');
+    const entries: ScoreEntry[] = users.map((u: any) => {
+      const progress = JSON.parse(localStorage.getItem(`english-warrior-progress-${u.id}`) || 'null');
+      const points = progress?.totalPoints || 0;
+      return { id: u.id, name: u.name, points } as ScoreEntry;
+    }) as ScoreEntry[];
+
+    entries.sort((a, b) => b.points - a.points);
+    setScores(entries.slice(0, 10));
+  }, []);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-6 bg-gradient-to-b from-purple-700 via-purple-800 to-purple-900 text-white">
+      <h1 className="text-4xl font-bold mb-8">🏆 Scoreboard</h1>
+      <div className="w-full max-w-md bg-white/10 backdrop-blur-md rounded-lg p-6">
+        {scores.length === 0 && <p className="text-center">No scores yet.</p>}
+        <ul className="space-y-3">
+          {scores.map((s, idx) => (
+            <li key={s.id} className="flex justify-between border-b border-white/20 pb-2">
+              <span>{idx + 1}. {s.name}</span>
+              <span>{s.points} pts</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <Link href="/galaxy" className="mt-8 bg-white text-purple-700 px-4 py-2 rounded font-bold shadow">
+        ← Back to Galaxy
+      </Link>
+    </div>
+  );
+}

--- a/src/lib/monsters.ts
+++ b/src/lib/monsters.ts
@@ -1,0 +1,46 @@
+import { Planet } from '@/types/curriculum';
+
+export interface Monster {
+  id: string;
+  name: string;
+  emoji: string;
+}
+
+export const planetMonsters: Record<Planet, Monster[]> = {
+  mercury: [
+    { id: 'mercury-1', name: 'Solar Sprite', emoji: '☀️' },
+    { id: 'mercury-2', name: 'Crater Critter', emoji: '🪨' },
+  ],
+  venus: [
+    { id: 'venus-1', name: 'Lava Lurker', emoji: '🌋' },
+    { id: 'venus-2', name: 'Cloud Phantom', emoji: '☁️' },
+  ],
+  earth: [
+    { id: 'earth-1', name: 'Forest Fiend', emoji: '🌲' },
+    { id: 'earth-2', name: 'Ocean Ogre', emoji: '🌊' },
+  ],
+  mars: [
+    { id: 'mars-1', name: 'Dust Demon', emoji: '💨' },
+    { id: 'mars-2', name: 'Red Rock Goblin', emoji: '🪨' },
+  ],
+  jupiter: [
+    { id: 'jupiter-1', name: 'Storm Beast', emoji: '🌩️' },
+    { id: 'jupiter-2', name: 'Gas Giant Goblin', emoji: '🌀' },
+  ],
+  saturn: [
+    { id: 'saturn-1', name: 'Ring Wraith', emoji: '💍' },
+    { id: 'saturn-2', name: 'Titan Troll', emoji: '👹' },
+  ],
+  uranus: [
+    { id: 'uranus-1', name: 'Ice Imp', emoji: '❄️' },
+    { id: 'uranus-2', name: 'Tilted Trickster', emoji: '🌀' },
+  ],
+  neptune: [
+    { id: 'neptune-1', name: 'Sea Serpent', emoji: '🐉' },
+    { id: 'neptune-2', name: 'Wind Wisp', emoji: '🌊' },
+  ],
+  pluto: [
+    { id: 'pluto-1', name: 'Frozen Fiend', emoji: '🧊' },
+    { id: 'pluto-2', name: 'Shadow Specter', emoji: '👻' },
+  ],
+};


### PR DESCRIPTION
## Summary
- add new scoreboard page to show top scores
- link scoreboard from homepage
- introduce per-planet monsters and display them on the galaxy screen

## Testing
- `npm run lint` *(fails: `next` not found)*